### PR TITLE
Update to Typescript 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta17 (Jesse Bye)
+
+- Release new version with Typescript dependency updated to ^4.x.
+
 1.0.0-beta16 (Dan Reynolds)
 
 - Release new version with React dependencies removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta13",
+  "version": "1.0.0-beta16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta16",
+  "version": "1.0.0-beta17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.11.tgz",
-      "integrity": "sha512-54+D5FB6RJlQ+g37f432gaexnyvDsG5X6L9VO5kqN54HJlbF8hCf/8CXtAQEHCWodAwZhy6kOLp2RM96829q3A==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.12.tgz",
+      "integrity": "sha512-1wLVqRpujzbLRWmFPnRCDK65xapOe2txY0sTI+BaqEbumMUVNS3vxojT6hRHf9ODFEK+F6MLrud2HGx0mB3eQw==",
       "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
@@ -20,7 +20,7 @@
         "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.6.0",
+        "ts-invariant": "^0.6.2",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
       }
@@ -823,9 +823,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.2.tgz",
-      "integrity": "sha512-yi0VRqw+ygqM/WVZUze5meAhe2evOHBFXqK8onNVdNNB+Tyn8/07FZpeDklECBHeT9KN9DY2JpCVGNQY6RCRDg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.4.tgz",
+      "integrity": "sha512-1gQQhCPenzxw/1HzLlvSIs/59eBHJf9ZDIussjjZhqNSqQuPKQIzN6SWt4kemvlBPDi7RqMuUa03pId7MAE93g==",
       "dev": true,
       "requires": {
         "tslib": "^1.14.1"
@@ -3812,9 +3812,9 @@
       }
     },
     "optimism": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
-      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.1.tgz",
+      "integrity": "sha512-7+1lSN+LJEtaj3uBLLFk8uFCFKy3txLvcvln5Dh1szXjF9yghEMeWclmnk0qdtYZ+lcMNyu48RmQQRw+LRYKSQ==",
       "dev": true,
       "requires": {
         "@wry/context": "^0.5.2",
@@ -4991,9 +4991,9 @@
       }
     },
     "ts-invariant": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
-      "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.2.tgz",
+      "integrity": "sha512-hsVurayufl1gXg8CHtgZkB7X0KtA3TrI3xcJ9xkRr8FeJHnM/TIEQkgBq9XkpduyBWWUdlRIR9xWf4Lxq3LJTg==",
       "dev": true,
       "requires": {
         "@types/ungap__global-this": "^0.3.1",
@@ -5071,9 +5071,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "@types/uuid": "^7.0.4",
     "graphql": "^15.5.0",
     "lodash": "^4.17.20",
-    "typescript": "^3.9.9",
+    "typescript": "^4.2.3",
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@apollo/client": "^3.3.7",
+    "@apollo/client": "^3.3.12",
     "@types/jest": "^25.2.3",
     "jest": "^25.5.4",
     "jest-extended": "^0.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta16",
+  "version": "1.0.0-beta17",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/entity-store/types.ts
+++ b/src/entity-store/types.ts
@@ -48,7 +48,7 @@ export interface ExtractedTypeMap {
 
 export interface NormalizedCacheObjectWithInvalidation
   extends NormalizedCacheObject {
-  invalidation: {
+  invalidation?: {
     entitiesById: EntitiesById;
   };
 }


### PR DESCRIPTION
We need Typescript 4.x as a dependency since using 3.x breaks our `tsc` on projects that use Typescript 4. All tests are passing.