### PR TITLE
Entity collection querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.0 (Dan Reynolds)
+
+- Adds experimental normalized collections
+
 1.2.1 (Dan Reynolds)
 
 - Publish publicly. Sorry OSS friends!

--- a/README.md
+++ b/README.md
@@ -10,31 +10,25 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
 * Invalidation policies that codify relationships between types in the cache when entities are written or evicted `(Ex. On write X, update Y)`.
 * More features coming soon!
 
-<details>
-  <summary>
-    Installation
-  </summary>
+## Installation
 
-  <br>
-
-  ```
-  npm install @nerdwallet/apollo-cache-policies
-  ```
-</details>
+```
+npm install @nerdwallet/apollo-cache-policies
+```
+## Features
 
 <details>
   <summary>
-    Type TTLs
+    Type Time-To-Lives (TTLs)
   </summary>
 
   <br>
 
   ## Summary
 
-  Type-based TTLs are useful when you want to specify requirements on how long an instance of a specific type should live in the cache before it becomes stale and unusable. When an entity is attempted to be read from the cache, it will be lazily evicted if its TTL has expired and will trigger any queries watching that data to rerun in order to
-  fetch the latest values.
+  Type-based TTLs are useful when you want to specify requirements on how long an instance of a specific type should live in the cache before it becomes stale and unusable. When an entity is attempted to be read from the cache, it will be lazily evicted if it has been in the cache longer than it's TTL duration (specified in milliseconds) and will trigger any queries watching that data to rerun in order to fetch new data.
 
-  ## Usage
+  ## Specification
 
   ```javascript
   import { InvalidationPolicyCache } from '@nerdwallet/apollo-cache-policies';
@@ -53,14 +47,37 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
     }
   });
   ```
-  ### Extended Type API
+
+  ## Example Usage
+
+  ```javascript
+  import { InvalidationPolicyCache, RenewalPolicy } from '@nerdwallet/apollo-cache-policies';
+
+  const cache = new InvalidationPolicyCache({
+    typePolicies: {...},
+    invalidationPolicies: {
+      timeToLive: 3600 * 1000; // 1hr TTL on all types in the cache
+      renewalPolicy: RenewalPolicy;
+      types: {
+        Employee: {
+          timeToLive: 3600 * 1000 * 24 // 24hr TTL specifically for the Employee type in the cache
+        },
+        EmployeeMessage: {
+          renewalPolicy: RenewalPolicy.AccessAndWrite // The TTL for employee messages is renewed when the a message is read or written in the cache
+        }
+      }
+    }
+  });
+  ```
+
+  ## Extended Type API
 
   | Config          | Description                                                                                | Required | Default   |
   | ----------------| -------------------------------------------------------------------------------------------|----------|-----------|
   | `timeToLive`    | The global time to live in milliseconds for all types in the cache                         | false    | None      |
   | `renewalPolicy` | The policy for renewing an entity's time to live in the cache                              | false    | WriteOnly |
 
-  ### Extended Cache APIs
+  ## Extended Cache APIs
 
   | Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                    |
   | -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|------------------------------|
@@ -91,7 +108,7 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
 
 <details>
   <summary>
-    Invalidation policies
+    Invalidation Policies
   </summary>
 
   <br>
@@ -100,7 +117,7 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
 
   Invalidation policies codify relationships between different types in the cache. Since the default `InMemoryCache` from Apollo is a key-value store, it does not maintain relationships between different cache entities. Invalidation policies introduce event-based (onWrite, onEvict) policies between parent/child type entities.
 
-  ## Usage
+  ## Specification
 
   ```javascript
   import { InvalidationPolicyCache } from '@nerdwallet/apollo-cache-policies';
@@ -120,45 +137,7 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
   });
   ```
 
-  ### Extended Cache API
-
-  The extended policies are by default triggered for on read, write or eviction of entities in the cache by type. If you want to enable or disable particular support for particular events in your application,
-  this can be done with the extended cache APIs for policy events.
-
-  | Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                    |
-  | -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|------------------------------|
-  | `activePolicyEvents`     | Returns all active policy events (Read, Write, Evict)                                     | InvalidationPolicyEvent[] - List of active policy events     | N/A                          |
-  | `activatePolicyEvents`   | Activates the provided policy events, defaults to all                                     | void                                                         | ...InvalidationPolicyEvent[] |
-  | `deactivatePolicyEvents` | Dectivates the provided policy events, defaults to all                                    | void                                                         | ...InvalidationPolicyEvent[] |
-
-  ### Policy Action Entity API
-
-  When an invalidation policy event is triggered, it will provide you with all the metadata required about which parent entity triggered the event and which child entity is affected.
-
-  | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
-  | ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|
-  | `id`                 | The id of the entity in the Apollo cache                | string              | `Employee:1`, `ROOT_QUERY`                                                                  |
-  | `ref`                | The reference object for the entity in the Apollo cache | Reference           | `{ __ref: 'Employee:1' }`, `{ __ref: 'ROOT_QUERY' }`                                        |
-  | `fieldName`          | The field for the entity in the Apollo cache            | string?             | `employees`                                                                                 |
-  | `storeFieldName`     | The `fieldName` combined with its distinct variables    | string?             | `employees({ location: 'US' })`                                                             |
-  | `variables`          | The variables the entity was written with               | Object?             | `{ location: 'US' }`                                                                        |
-  | `args`               | The args the field was written with                     | Object?             | `{ location: 'US' }`                                                                        |
-  | `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                    |
-  | `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
-
-  | Default Policy Action Entity | Description                                                                   | Type               | Example                                                                                     |
-  | -----------------------------| ------------------------------------------------------------------------------|---------------------| ---------------------------------------------------------------------------------------------|
-  | `storage`                    | An object for storing unique entity metadata across policy action invocations | Object              | `{}`                                                                        |
-  | `parent`                     | The parent entity that triggered the PolicyEvent                              | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
-</details>
-
-
-<details>
-  <summary>
-    Example usage
-  </summary>
-
-  <br>
+  ## Example Usage
 
   ```javascript
   import { ApolloClient, InMemoryCache } from "@apollo/client";
@@ -222,161 +201,149 @@ An extension of the [Apollo 3.0 cache](https://blog.apollographql.com/previewing
                 });
               },
             },
-            EmployeesResponse: {
-              // Assign a time-to-live for types in the store. If accessed beyond their TTL,
-              // they are evicted and no data is returned.
-              timeToLive: 3600,
-            }
           },
         }
       }
     })
   });
   ```
+  ## Invalidation Policies Cache API
+
+  The extended policies are by default triggered for on read, write or eviction of entities in the cache by type. If you want to enable or disable particular support for particular events in your application,
+  this can be done with the extended cache APIs for policy events.
+
+  | Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                    |
+  | -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|------------------------------|
+  | `activePolicyEvents`     | Returns all active policy events (Read, Write, Evict)                                     | InvalidationPolicyEvent[] - List of active policy events     | N/A                          |
+  | `activatePolicyEvents`   | Activates the provided policy events, defaults to all                                     | void                                                         | ...InvalidationPolicyEvent[] |
+  | `deactivatePolicyEvents` | Dectivates the provided policy events, defaults to all                                    | void                                                         | ...InvalidationPolicyEvent[] |
+
+  ## Policy Action Entity API
+
+  When an invalidation policy event is triggered, it will provide you with all the metadata required about which parent entity triggered the event and which child entity is affected.
+
+  | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
+  | ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|
+  | `id`                 | The id of the entity in the Apollo cache                | string              | `Employee:1`, `ROOT_QUERY`                                                                  |
+  | `ref`                | The reference object for the entity in the Apollo cache | Reference           | `{ __ref: 'Employee:1' }`, `{ __ref: 'ROOT_QUERY' }`                                        |
+  | `fieldName`          | The field for the entity in the Apollo cache            | string?             | `employees`                                                                                 |
+  | `storeFieldName`     | The `fieldName` combined with its distinct variables    | string?             | `employees({ location: 'US' })`                                                             |
+  | `variables`          | The variables the entity was written with               | Object?             | `{ location: 'US' }`                                                                        |
+  | `args`               | The args the field was written with                     | Object?             | `{ location: 'US' }`                                                                        |
+  | `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                    |
+  | `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
+
+  | Default Policy Action Entity | Description                                                                   | Type               | Example                                                                                     |
+  | -----------------------------| ------------------------------------------------------------------------------|---------------------| ---------------------------------------------------------------------------------------------|
+  | `storage`                    | An object for storing unique entity metadata across policy action invocations | Object              | `{}`                                                                        |
+  | `parent`                     | The parent entity that triggered the PolicyEvent                              | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
+
 </details>
 
 <details>
   <summary>
-    Why does this exist?
+    Normalized Collections
   </summary>
 
   <br>
 
-The Apollo client cache is a powerful tool for managing client data with support for optimistic data, request retrying, polling and with Apollo 3.0, robust cache modification and eviction.
+  ## Normalized Collections
 
-The client cache stores entries in a normalized data model. A query for fetching a list of employees like this:
+  Normalized collections introduce ways of accessing and filtering all entities in the cache of a given type. They are useful for scenarios where clients may want to access all entities in the cache of a particular type matching a set of filters like a list of all products to show or all the messages of a conversation. To read more about the motivation for this feature, check out [this blog post](https://danreynolds.ca/tech/2021/09/23/Apollo-Normalized-Collections/).
 
-```javascript
-import gql from "@apollo/client";
+  To use normalized collections, enable it in the cache with the collections flag below:
 
-const employeesQuery = gql`
-  query GetEmployees {
-    employees {
-      id
-      name
+  ```javascript
+  import { InvalidationPolicyCache } from '@nerdwallet/apollo-cache-policies';
+
+  const cache = new InvalidationPolicyCache({
+    enableCollections: true,
+    typePolicies: {...},
+    invalidationPolicies: {...}
+  });
+  ```
+
+  ## Specification
+
+  Normalized collections introduce 4 new APIs:
+
+  1. `useFragmentWhere`: A new React hook for filtering a collection of entities by type
+  2. `cache.readReferenceWhere`: A cache API that returns a list of references in the cache for a particular type and filter
+  3. `cache.readFragmentWhere`: The collection filter equivalent of the existing cache.readFragment API
+  4. `cache.watchFragmentWhere`: The collection filter equivalent of the existing cache.watchFragment API
+
+  ## useFragmentWhere
+
+  The `useFragmentWhere` API allows us to query for a filtered collection of entities by type. It takes two arguments, a GraphQL fragment for the fields to read from the type and an object of all the fields to filter by.
+
+  ### Example Usage
+
+  Now our client can filter all entites of a particular type in the cache like `Employee` in one operation without having to write any type policies.
+
+  ```js
+  import { useFragmentWhere } from '@nerdwallet/apollo-cache-policies';
+
+  const { data } = useFragmentWhere(
+    gql`
+      fragment EmployeesByTeam on Employee {
+        id
+        name
+      }
+    `,
+    {
+      team: 'Banking',
     }
-  }
-`;
-```
+  )
+  ```
 
-Would be represented in the cache like this:
+  If we just want to retrieve all entities in the cache for a particular type, we can omit the filter altogether:
 
-```javascript
-{
-    ROOT_QUERY: {
-        __typename: 'Query',
-        employees: {
-            __typename: 'EmployeesResponse',
-            data: [{ __ref: 'Employee:1' }, { __ref: 'Employee:2' }]
-        }
-    },
-    'Employee:1': {
-        __typename: 'Employee',
-        id: 1,
-        name: 'Alice',
-    },
-    'Employee:2': {
-        __typename: 'Employee',
-        id: 2,
-        name: 'Bob',
-    }
-}
-```
+  ```js
+  import { useFragmentWhere } from '@nerdwallet/apollo-cache-policies';
 
-Invalidation in the Apollo cache is limited and is a common source of consternation in the Apollo community:
+  const { data } = useFragmentWhere(
+    gql`
+      fragment AllEmployees on Employee {
+        id
+        name
+      }
+    `
+  )
+  ```
 
-- https://github.com/apollographql/apollo-client/issues/899
-- https://github.com/apollographql/apollo-feature-requests/issues/4
-- https://github.com/apollographql/apollo-feature-requests/issues/5#issuecomment-491024981
+  The `useFragmentWhere` API will automatically update the component just like `useQuery` when the employees that match the filter change, including when a new employee that matches the filter criteria is added to the cache.
 
-The automatic cache invalidation provided by Apollo is missing two categories of cache invalidation:
+  > Note: `useFragmentWhere` subscribes to data changes based on the fragment name you provide, so to return different data from different calls to the API you will want to use different fragment names.
 
-### 1. Creating/deleting entities
+  ## Cache.readReferenceWhere
 
-Because it uses a normalized data cache, any updates to entities in the cache will be consistent across cached queries that contain them such as in lists or nested data objects. This does not work when creating or deleting entities, however, since it does not know to add any new entities to cached queries or remove them when a mutation deletes an entity from the server.
+  Normalized collections can be accessed in type policies using the new `cache.readReferenceWhere` API. `readReferenceWhere` will return a list of references for a given type and filter.
 
-The Apollo cache allows clients to handle these scenarios with a query update handler:
+  ### Example Usage
 
-```javascript
-const createEntity = await apolloClient.mutate({
-  mutation: CreateEntity,
-  variables: newEntityData
-  update: (cache, { data: createEntityResult }) => {
-    const cachedEntities = cache.readQuery({ query: GetAllEntities });
-    cache.writeQuery({
-      query: GetAllEntities,
-      data: {
-        GetAllEntities: {
-          __typename: 'GetEntityResponse',
-          entities: [...cachedEntities.entities, createEntityResult.entity],
+  ```js
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          readBankingTeam: {
+            read(_existingBankingTeam, { cache }) {
+              return cache.readReferenceWhere(
+                {
+                  __typename: 'Employee',
+                  filter: {
+                    team: 'Banking',
+                  },
+                }
+              );
+            }
+          },
         },
       },
-    });
-  },
-});
-```
+    },
+  });
+  ```
 
-This requires the client to specify an update handler at the mutation call site and manually read, modify and write that data back into the cache. While this works, the code does not scale well across multiple usages of the same mutation or for highly relational data where a mutation needs to invalidate various cached entities.
-
-### 2. Cache dependencies
-
-The Apollo cache has powerful utilities for interacting with the cache, but does not have a framework for managing the lifecycle and dependencies between entities in the cache.
-
-If a cache contains multiple entities like a user's profile, messages, and posts, then deleting their profile should invalidate all cached queries containing their messages and posts.
-
-</details>
-
-<details>
-  <summary>
-    FAQs
-  </summary>
-
-  <br>
-
-### What use cases is this project targetting?
-
-The Apollo cache is not a relational datastore and as an extension of it, these cache policies are not going to be the best solution for every project. At its core it's a for loop that runs for each child x of type T when a matching policy event occurs for parent entity y of type T2. If your cache will consist of thousands of x's and y's dependent on each other with frequent policy triggers, then something like a client-side database would be a better choice. Our goal has been decreasing developer overhead when having to manage the invalidation of multiple of distinct, dependent cached queries.
-
-### Why extend the cache instead of using an Apollo link?
-
-Apollo links are great tools for watching queries and mutations hitting the network. There even exists a [Watched Mutation](https://github.com/afafafafafaf/apollo-link-watched-mutation) link which provides some of the desired behavior of this library.
-
-At a high level, links run on the network-bound queries/mutations. These additional policies run on the types
-that are being written and evicted from your cache, which this library believes is a better level at which to manage cache operations.
-
-At a low level, links:
-
-- Only process queries/mutations that hit the network, so they will not work for operations hitting only the cache including `@client` directive queries and mutations.
-- Cannot form type relationships, only query/mutation relationships. If a mutation for deleting an Employee cache entry should also delete all their
-  EmployeeMessage and EmployeePost types, links cannot represent that type to type relationship.
-- Links miss directly modified cached data. If eviction of an Employee cache entity occurs because the client called `cache.evict` directly, links will not be able to process
-  anything in relation to what should happen in response to that eviction.
-
-### Why not establish schema relationships on the server?
-
-This was also something that was explored, and it is possible to do this with custom directives:
-
-```javascript
-  type Employee @invalidates(own: [EmployeeMessage, EmployeePost]) {
-    id
-  }
-  type DeleteEmployeeResponse {
-    success: Boolean!
-  }
-  type TotalEmployeesResponse {
-    count: Number!
-  }
-  extend type Query {
-    totalEmployees(
-    ): TotalEmployeesResponse
-  }
-  extend type Mutation {
-    deleteFinancialPortal(
-      financialPortalId: ID!
-    ): DeleteFinancialPortalResponse @invalidates(own: [Employee], any: [TotalEmployeesResponse])
-  }
-```
-
-These schema rules could then be consumable on the client either via a `invalidationSchema` introspection query, or just an exported file. We looked into this but found it more limiting for now because of the limited ability of the schema language to express complex scenarios.
+  In this example, we use the `readReferenceWhere` API to construct a type policy that returns all entities of the `Employee` type in the cache with a field `team` matching the value `Banking`. Any number of fields can be used as filters and queries for this type policy will automatically update whenever an employee is created or mutated.
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -769,6 +769,29 @@
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.19",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
+      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1474,6 +1497,12 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4053,6 +4082,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/NerdWalletOSS/apollo-cache-policies#readme",
   "peerDependencies": {
     "@apollo/client": "^3.3.0",
-    "react": "^16.0.0"
+    "react": "^16.8.0"
   },
   "dependencies": {
     "@types/graphql": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/NerdWalletOSS/apollo-cache-policies#readme",
   "peerDependencies": {
-    "@apollo/client": "^3.3.0"
+    "@apollo/client": "^3.3.0",
+    "react": "^16.0.0"
   },
   "dependencies": {
     "@types/graphql": "^14.5.0",
@@ -41,9 +42,11 @@
   "devDependencies": {
     "@apollo/client": "^3.3.19",
     "@types/jest": "^25.2.3",
+    "@types/react": "^17.0.19",
     "jest": "^25.5.4",
     "jest-extended": "^0.11.5",
     "prettier": "2.0.5",
+    "react": "^17.0.2",
     "subscriptions-transport-ws": "^0.9.18",
     "ts-jest": "^25.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/audit/InvalidationPolicyCacheAuditor.ts
+++ b/src/audit/InvalidationPolicyCacheAuditor.ts
@@ -18,7 +18,7 @@ export default class InvalidationPolicyCacheAuditor extends InvalidationPolicyCa
       entityStore: this.entityStoreRoot,
       entityTypeMap: this.entityTypeMap,
       policies: this.policies,
-      updateCanonicalField: this.updateCanonicalField.bind(this),
+      updateCollectionField: this.updateCollectionField.bind(this),
     });
     this.invalidationPolicyManager = new InvalidationPolicyManagerAuditor({
       auditLog: this.auditLog,

--- a/src/audit/InvalidationPolicyCacheAuditor.ts
+++ b/src/audit/InvalidationPolicyCacheAuditor.ts
@@ -18,6 +18,7 @@ export default class InvalidationPolicyCacheAuditor extends InvalidationPolicyCa
       entityStore: this.entityStoreRoot,
       entityTypeMap: this.entityTypeMap,
       policies: this.policies,
+      updateCanonicalField: this.updateCanonicalField.bind(this),
     });
     this.invalidationPolicyManager = new InvalidationPolicyManagerAuditor({
       auditLog: this.auditLog,

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -484,7 +484,6 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     }
 
     return entityReferences.filter(ref => {
-      debugger;
       if (_.isFunction(filter)) {
         return filter(ref, this.readField.bind(this));
       }

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -235,7 +235,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
       this.writeFragment({
         id: collectionEntityId,
         fragment: gql`
-          fragment X on CacheExtensionsCollectionEntity {
+          fragment InitializeCollectionEntity on CacheExtensionsCollectionEntity {
             data
             id
           }
@@ -437,6 +437,8 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     return extractedCache;
   }
 
+  // Supports reading a collection of entities by type from the cache and filtering them by the given fields. Returns
+  // a list of the dereferenced matching entities from the cache based on the given fragment.
   readFragmentWhere<FragmentType, TVariables = any>(options: Cache.ReadFragmentOptions<FragmentType, TVariables> & {
     filters: Partial<Record<keyof FragmentType, any>>
   }): FragmentType[] {
@@ -460,6 +462,8 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     return _.compact(matchingFragments);
   }
 
+  // Supports reading a collection of references by type from the cache and filtering them by the given fields. Returns a
+  // list of the matching references.
   readReferenceWhere<T>(options: Partial<Record<keyof T, any>> & {
     __typename: string,
   }) {

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -18,7 +18,3 @@ export interface CacheResultProcessorConfig {
   invalidationPolicyManager: InvalidationPolicyManager;
   cache: InvalidationPolicyCache;
 }
-
-export interface InvalidationPolicyCacheExtensions {
-  readFragmentWhere<FragmentType, TVariables = any>(options: Cache.ReadFragmentOptions<FragmentType, TVariables>) : null;
-}

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,4 +1,4 @@
-import { Cache, InMemoryCacheConfig } from "@apollo/client/core";
+import { Cache, InMemoryCacheConfig, Reference } from "@apollo/client/core";
 import { InvalidationPolicies, PolicyActionMeta } from "../policies/types";
 import { EntityTypeMap } from "../entity-store";
 import InvalidationPolicyManager from "../policies/InvalidationPolicyManager";
@@ -19,3 +19,5 @@ export interface CacheResultProcessorConfig {
   invalidationPolicyManager: InvalidationPolicyManager;
   cache: InvalidationPolicyCache;
 }
+
+export type FragmentWhereFilter<T> = Partial<Record<keyof T, any>> | ((__ref: Reference, readField: InvalidationPolicyCache['readField']) => boolean);

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -6,6 +6,7 @@ import { InvalidationPolicyCache } from ".";
 
 export interface InvalidationPolicyCacheConfig extends InMemoryCacheConfig {
   invalidationPolicies?: InvalidationPolicies;
+  enableCollections?: boolean;
 }
 
 export interface InvalidationPolicyCacheEvictOptions

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -18,3 +18,7 @@ export interface CacheResultProcessorConfig {
   invalidationPolicyManager: InvalidationPolicyManager;
   cache: InvalidationPolicyCache;
 }
+
+export interface InvalidationPolicyCacheExtensions {
+  readFragmentWhere<FragmentType, TVariables = any>(options: Cache.ReadFragmentOptions<FragmentType, TVariables>) : null;
+}

--- a/src/cache/utils.ts
+++ b/src/cache/utils.ts
@@ -1,5 +1,5 @@
-export const cacheExtensionsCanonicalEntityTypename = 'CacheExtensionsCanonicalEntity';
+export const cacheExtensionsCollectionTypename = 'CacheExtensionsCollectionEntity';
 
-export function canonicalEntityIdForType(typename: string) {
-  return `${cacheExtensionsCanonicalEntityTypename}:${typename}`;
+export function collectionEntityIdForType(typename: string) {
+  return `${cacheExtensionsCollectionTypename}:${typename}`;
 }

--- a/src/cache/utils.ts
+++ b/src/cache/utils.ts
@@ -1,0 +1,5 @@
+export const cacheExtensionsCanonicalEntityTypename = 'CacheExtensionsCanonicalEntity';
+
+export function canonicalEntityIdForType(typename: string) {
+  return `${cacheExtensionsCanonicalEntityTypename}:${typename}`;
+}

--- a/src/client/ApolloExtensionsClient.ts
+++ b/src/client/ApolloExtensionsClient.ts
@@ -1,0 +1,44 @@
+import {
+  ApolloClient,
+  ApolloClientOptions,
+  ObservableQuery,
+  OperationVariables,
+} from '@apollo/client/core';
+import { Policies } from '@apollo/client/cache/inmemory/policies';
+import { buildWatchFragmentQuery, buildWatchFragmentWhereQuery } from './utils';
+import { InvalidationPolicyCache } from '../cache';
+import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
+
+export default class ApolloExtensionsClient<TCacheShape> extends ApolloClient<TCacheShape> {
+  protected policies: Policies;
+
+  constructor(config: ApolloClientOptions<TCacheShape>) {
+    super(config);
+
+    // @ts-ignore
+    this.policies = this.cache.policies;
+  }
+
+  watchFragment<T = any, TVariables = OperationVariables>(
+    options: WatchFragmentOptions,
+  ): ObservableQuery<T, TVariables> {
+    return this.watchQuery({
+      fetchPolicy: 'cache-only',
+      query: buildWatchFragmentQuery({
+        ...options,
+        policies: this.policies,
+      }),
+    });
+  }
+
+  watchFragmentWhere<FragmentType>(options: WatchFragmentWhereOptions<FragmentType>) {
+    return this.watchQuery({
+      fetchPolicy: 'cache-only',
+      query: buildWatchFragmentWhereQuery({
+        ...options,
+        cache: this.cache as unknown as InvalidationPolicyCache,
+        policies: this.policies,
+      }),
+    });
+  }
+}

--- a/src/client/ApolloExtensionsClient.ts
+++ b/src/client/ApolloExtensionsClient.ts
@@ -9,6 +9,8 @@ import { buildWatchFragmentQuery, buildWatchFragmentWhereQuery } from './utils';
 import { InvalidationPolicyCache } from '../cache';
 import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
 
+// An extension of the Apollo client that add support for watching updates to entities
+// and collections of entities based on the provided filters.
 export default class ApolloExtensionsClient<TCacheShape> extends ApolloClient<TCacheShape> {
   protected policies: Policies;
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,1 @@
+export { default as ApolloExtensionsClient } from './ApolloExtensionsClient';

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,11 @@
+import { DocumentNode } from 'graphql';
+
+export type WatchFragmentOptions = {
+  fragment: DocumentNode,
+  id: string;
+}
+
+export type WatchFragmentWhereOptions<FragmentType> = {
+  fragment: DocumentNode;
+  filters: Partial<Record<keyof FragmentType, any>>;
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,5 @@
 import { DocumentNode } from 'graphql';
+import { Reference } from "@apollo/client/core";
 
 export type WatchFragmentOptions = {
   fragment: DocumentNode,
@@ -7,5 +8,5 @@ export type WatchFragmentOptions = {
 
 export type WatchFragmentWhereOptions<FragmentType> = {
   fragment: DocumentNode;
-  filters: Partial<Record<keyof FragmentType, any>>;
+  filter: Partial<Record<keyof FragmentType, any>> | ((__ref: Reference) => boolean);
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { Reference } from "@apollo/client/core";
+import { FragmentWhereFilter } from '../cache/types';
 
 export type WatchFragmentOptions = {
   fragment: DocumentNode,
@@ -8,5 +8,5 @@ export type WatchFragmentOptions = {
 
 export type WatchFragmentWhereOptions<FragmentType> = {
   fragment: DocumentNode;
-  filter: Partial<Record<keyof FragmentType, any>> | ((__ref: Reference) => boolean);
+  filter?: FragmentWhereFilter<FragmentType>;
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -3,7 +3,7 @@ import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
 import { InvalidationPolicyCache } from '../cache';
 import { Policies } from '@apollo/client/cache/inmemory/policies';
 import { makeReference } from '@apollo/client/core';
-// import { canonicalEntityIdForType } from '../cache/utils';
+// import { collectionEntityIdForType } from '../cache/utils';
 
 function _generateQueryFromFragment({
   fieldName,

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,0 +1,111 @@
+import { DocumentNode, FragmentDefinitionNode } from 'graphql';
+import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
+import { InvalidationPolicyCache } from '../cache';
+import { Policies } from '@apollo/client/cache/inmemory/policies';
+import { makeReference } from '@apollo/client/core';
+// import { canonicalEntityIdForType } from '../cache/utils';
+
+function _generateQueryFromFragment({
+  fieldName,
+  fragmentDefinition,
+}: {
+  fieldName: string;
+  fragmentDefinition: FragmentDefinitionNode;
+}): DocumentNode {
+  return {
+    kind: 'Document',
+    definitions: [
+      {
+        directives: [],
+        variableDefinitions: [],
+        kind: 'OperationDefinition',
+        operation: 'query',
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: [
+            {
+              arguments: [],
+              kind: "Field",
+              name: { kind: "Name", value: fieldName },
+              directives: [
+                {
+                  arguments: [],
+                  kind: 'Directive',
+                  name: { kind: "Name", value: "client" },
+                },
+              ],
+              selectionSet: fragmentDefinition.selectionSet,
+            },
+          ]
+        },
+      }
+    ],
+  };
+}
+
+export function buildWatchFragmentQuery(
+  options: WatchFragmentOptions & {
+    policies: Policies,
+  }
+): DocumentNode {
+  const { fragment, id, policies } = options;
+  const fragmentDefinition = fragment.definitions[0] as FragmentDefinitionNode;
+  const fragmentName = fragmentDefinition.name.value;
+
+  const query = _generateQueryFromFragment({
+    fragmentDefinition: fragmentDefinition,
+    fieldName: fragmentName,
+  });
+
+  // @ts-ignore
+  if (!policies.getFieldPolicy('Query', fragmentName)) {
+    policies.addTypePolicies({
+      Query: {
+        fields: {
+          [fragmentName]: {
+            read(_existing) {
+              return makeReference(id);
+            }
+          }
+        }
+      }
+    });
+  }
+
+  return query;
+}
+
+export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmentWhereOptions<FragmentType> & {
+  cache: InvalidationPolicyCache,
+  policies: Policies,
+}): DocumentNode {
+  const { fragment, filters, policies, cache } = options;
+  const fragmentDefinition = fragment.definitions[0] as FragmentDefinitionNode;
+  const fragmentName = fragmentDefinition.name.value;
+  const __typename = fragmentDefinition.typeCondition.name.value;
+
+  const query = _generateQueryFromFragment({
+    fragmentDefinition,
+    fieldName: fragmentName,
+  });
+
+  // @ts-ignore
+  if (!policies.getFieldPolicy('Query', fragmentName)) {
+    policies.addTypePolicies({
+      Query: {
+        fields: {
+          [fragmentName]: {
+            read(_existing) {
+              return cache.readReferenceWhere({
+                __typename,
+                ...filters,
+              });
+            }
+          }
+        }
+      }
+    });
+  }
+
+  return query;
+}

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -3,7 +3,6 @@ import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
 import { InvalidationPolicyCache } from '../cache';
 import { Policies } from '@apollo/client/cache/inmemory/policies';
 import { makeReference } from '@apollo/client/core';
-// import { collectionEntityIdForType } from '../cache/utils';
 
 function _generateQueryFromFragment({
   fieldName,

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -43,6 +43,8 @@ function _generateQueryFromFragment({
   };
 }
 
+// Returns a query that can be used to watch a normalized cache entity by converting the fragment to a query
+// and dynamically adding a type policy that returns the entity.
 export function buildWatchFragmentQuery(
   options: WatchFragmentOptions & {
     policies: Policies,
@@ -57,7 +59,9 @@ export function buildWatchFragmentQuery(
     fieldName: fragmentName,
   });
 
-  // @ts-ignore
+  // @ts-ignore The getFieldPolicy is private but we need it here to determine
+  // if the dynamic type policy we generate for the corresponding fragment has
+  // already been added
   if (!policies.getFieldPolicy('Query', fragmentName)) {
     policies.addTypePolicies({
       Query: {
@@ -75,6 +79,8 @@ export function buildWatchFragmentQuery(
   return query;
 }
 
+// Returns a query that can be used to watch a filtered list of normalized cache entities by converting the fragment to a query
+// and dynamically adding a type policy that returns the list of matching entities.
 export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmentWhereOptions<FragmentType> & {
   cache: InvalidationPolicyCache,
   policies: Policies,
@@ -89,7 +95,9 @@ export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmen
     fieldName: fragmentName,
   });
 
-  // @ts-ignore
+  // @ts-ignore The getFieldPolicy is private but we need it here to determine
+  // if the dynamic type policy we generate for the corresponding fragment has
+  // already been added
   if (!policies.getFieldPolicy('Query', fragmentName)) {
     policies.addTypePolicies({
       Query: {

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -84,7 +84,7 @@ export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmen
   cache: InvalidationPolicyCache,
   policies: Policies,
 }): DocumentNode {
-  const { fragment, filters, policies, cache } = options;
+  const { fragment, filter, policies, cache } = options;
   const fragmentDefinition = fragment.definitions[0] as FragmentDefinitionNode;
   const fragmentName = fragmentDefinition.name.value;
   const __typename = fragmentDefinition.typeCondition.name.value;
@@ -105,7 +105,7 @@ export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmen
             read(_existing) {
               return cache.readReferenceWhere({
                 __typename,
-                ...filters,
+                filter,
               });
             }
           }

--- a/src/entity-store/EntityStoreWatcher.ts
+++ b/src/entity-store/EntityStoreWatcher.ts
@@ -4,13 +4,13 @@ import EntityTypeMap from "./EntityTypeMap";
 import { NormalizedCacheObjectWithInvalidation } from "./types";
 import { makeEntityId, isQuery } from "../helpers";
 import { Policies } from '@apollo/client/cache/inmemory/policies';
-import { cacheExtensionsCanonicalEntityTypename } from '../cache/utils';
+import { cacheExtensionsCollectionTypename } from '../cache/utils';
 
 interface EntityStoreWatcherConfig {
   entityStore: any;
   entityTypeMap: EntityTypeMap;
   policies: Policies;
-  updateCanonicalField: (typename: string, dataId: string) => void;
+  updateCollectionField: (typename: string, dataId: string) => void;
 }
 
 type EntityStoreWatcherStoreFunctions = {
@@ -95,8 +95,8 @@ export default class EntityStoreWatcher {
     } else {
       const typename = incomingStoreObject.__typename;
       // If the incoming data is empty, the dataId entry in the cache is being deleted so do nothing
-      if (dataId && typename && typename !== cacheExtensionsCanonicalEntityTypename) {
-        this.config.updateCanonicalField(typename, dataId);
+      if (dataId && typename && typename !== cacheExtensionsCollectionTypename) {
+        this.config.updateCollectionField(typename, dataId);
         entityTypeMap.write(typename, dataId);
       }
     }

--- a/src/entity-store/EntityStoreWatcher.ts
+++ b/src/entity-store/EntityStoreWatcher.ts
@@ -3,11 +3,14 @@ import { StoreObject } from "@apollo/client/core";
 import EntityTypeMap from "./EntityTypeMap";
 import { NormalizedCacheObjectWithInvalidation } from "./types";
 import { makeEntityId, isQuery } from "../helpers";
+import { Policies } from '@apollo/client/cache/inmemory/policies';
+import { cacheExtensionsCanonicalEntityTypename } from '../cache/utils';
 
 interface EntityStoreWatcherConfig {
   entityStore: any;
   entityTypeMap: EntityTypeMap;
-  policies: any;
+  policies: Policies;
+  updateCanonicalField: (typename: string, dataId: string) => void;
 }
 
 type EntityStoreWatcherStoreFunctions = {
@@ -92,7 +95,8 @@ export default class EntityStoreWatcher {
     } else {
       const typename = incomingStoreObject.__typename;
       // If the incoming data is empty, the dataId entry in the cache is being deleted so do nothing
-      if (dataId && typename) {
+      if (dataId && typename && typename !== cacheExtensionsCanonicalEntityTypename) {
+        this.config.updateCanonicalField(typename, dataId);
         entityTypeMap.write(typename, dataId);
       }
     }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useFragment } from './useFragment';
+export { default as useFragmentWhere } from './useFragmentWhere';

--- a/src/hooks/useFragment.ts
+++ b/src/hooks/useFragment.ts
@@ -1,5 +1,6 @@
 import { getApolloContext, useQuery } from '@apollo/client';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
+import { useOnce } from './utils';
 import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
 import { DocumentNode } from 'graphql';
 import { buildWatchFragmentQuery } from '../client/utils';
@@ -13,11 +14,11 @@ export default function useFragment(fragment: DocumentNode, options: UseFragment
   const client = context.client;
   const cache = client?.cache as unknown as InvalidationPolicyCache;
 
-  const query = useMemo(() => buildWatchFragmentQuery({
+  const query = useOnce(() => buildWatchFragmentQuery({
     fragment,
     id: options.id,
     policies: cache.policies,
-  }), []);
+  }));
 
   return useQuery(query, {
     fetchPolicy: 'cache-only',

--- a/src/hooks/useFragment.ts
+++ b/src/hooks/useFragment.ts
@@ -1,0 +1,25 @@
+import { getApolloContext, useQuery } from '@apollo/client';
+import { useContext, useMemo } from 'react';
+import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
+import { DocumentNode } from 'graphql';
+import { buildWatchFragmentQuery } from '../client/utils';
+
+interface UseFragmentOptions {
+  id: string;
+}
+
+export default function useFragment(fragment: DocumentNode, options: UseFragmentOptions) {
+  const context = useContext(getApolloContext());
+  const client = context.client;
+  const cache = client?.cache as unknown as InvalidationPolicyCache;
+
+  const query = useMemo(() => buildWatchFragmentQuery({
+    fragment,
+    id: options.id,
+    policies: cache.policies,
+  }), []);
+
+  return useQuery(query, {
+    fetchPolicy: 'cache-only',
+  });
+}

--- a/src/hooks/useFragmentWhere.ts
+++ b/src/hooks/useFragmentWhere.ts
@@ -3,8 +3,9 @@ import { useContext, useMemo } from 'react';
 import { DocumentNode } from 'graphql';
 import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
 import { buildWatchFragmentWhereQuery } from '../client/utils';
+import { FragmentWhereFilter } from '../cache/types';
 
-export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filter: Partial<Record<keyof FragmentType, any>>) {
+export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filter?: FragmentWhereFilter<FragmentType>) {
   const context = useContext(getApolloContext());
   const client = context.client;
   const cache = client?.cache as unknown as InvalidationPolicyCache;

--- a/src/hooks/useFragmentWhere.ts
+++ b/src/hooks/useFragmentWhere.ts
@@ -4,13 +4,13 @@ import { DocumentNode } from 'graphql';
 import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
 import { buildWatchFragmentWhereQuery } from '../client/utils';
 
-export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filters: Partial<Record<keyof FragmentType, any>>) {
+export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filter: Partial<Record<keyof FragmentType, any>>) {
   const context = useContext(getApolloContext());
   const client = context.client;
   const cache = client?.cache as unknown as InvalidationPolicyCache;
 
   const query = useMemo(() => buildWatchFragmentWhereQuery({
-    filters,
+    filter,
     fragment,
     cache,
     policies: cache.policies,

--- a/src/hooks/useFragmentWhere.ts
+++ b/src/hooks/useFragmentWhere.ts
@@ -1,0 +1,22 @@
+import { getApolloContext, useQuery } from '@apollo/client';
+import { useContext, useMemo } from 'react';
+import { DocumentNode } from 'graphql';
+import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
+import { buildWatchFragmentWhereQuery } from '../client/utils';
+
+export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filters: Partial<Record<keyof FragmentType, any>>) {
+  const context = useContext(getApolloContext());
+  const client = context.client;
+  const cache = client?.cache as unknown as InvalidationPolicyCache;
+
+  const query = useMemo(() => buildWatchFragmentWhereQuery({
+    filters,
+    fragment,
+    cache,
+    policies: cache.policies,
+  }), []);
+
+  return useQuery(query, {
+    fetchPolicy: 'cache-only',
+  });
+}

--- a/src/hooks/useFragmentWhere.ts
+++ b/src/hooks/useFragmentWhere.ts
@@ -1,21 +1,22 @@
 import { getApolloContext, useQuery } from '@apollo/client';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { DocumentNode } from 'graphql';
 import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
 import { buildWatchFragmentWhereQuery } from '../client/utils';
 import { FragmentWhereFilter } from '../cache/types';
+import { useOnce } from './utils';
 
 export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filter?: FragmentWhereFilter<FragmentType>) {
   const context = useContext(getApolloContext());
   const client = context.client;
   const cache = client?.cache as unknown as InvalidationPolicyCache;
 
-  const query = useMemo(() => buildWatchFragmentWhereQuery({
+  const query = useOnce(() => buildWatchFragmentWhereQuery({
     filter,
     fragment,
     cache,
     policies: cache.policies,
-  }), []);
+  }));
 
   return useQuery(query, {
     fetchPolicy: 'cache-only',

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+import { isFunction } from 'lodash';
+
+export function useOnce<T>(value: T | (() => T)): T {
+  const valueRef = useRef<T>();
+  const hasCachedValueRef = useRef(false);
+  if (!hasCachedValueRef.current) {
+    if (isFunction(value)) {
+      valueRef.current = value();
+    } else {
+      valueRef.current = value;
+    }
+    hasCachedValueRef.current = true;
+  }
+  return valueRef.current as T;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { InvalidationPolicyCache } from "./cache";
+export { ApolloExtensionsClient } from "./client";
+export { useFragment, useFragmentWhere } from './hooks';
 export { InvalidationPolicyCacheAuditor } from "./audit";
 export {
   DefaultPolicyAction,

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -1,6 +1,7 @@
-import { FieldNode } from 'graphql';
-import { Cache, Reference, StoreObject, StoreValue } from "@apollo/client/core";
 import EntityTypeMap from "../entity-store/EntityTypeMap";
+import { DocumentNode, FieldNode } from 'graphql';
+import { Cache, FieldFunctionOptions, Reference, StoreObject, StoreValue } from '@apollo/client';
+
 export interface FieldSpecifier {
   typename?: string;
   fieldName: string;
@@ -104,3 +105,30 @@ export interface InvalidationPolicyManagerConfig {
 export type InvalidationPolicyEventActivation = {
   [key in InvalidationPolicyEvent]: boolean;
 };
+export interface TypePoliciesSchemaInterface<TypedTypePolicies> {
+  typeDefs?: DocumentNode;
+  typePolicies: TypedTypePolicies;
+}
+
+export type DeepReference<SourceType> = SourceType extends Record<string, any>
+  ? SourceType extends { id: string }
+  ? Reference
+  : {
+    [K in keyof SourceType]: DeepReference<SourceType[K]>;
+  }
+  : SourceType extends Array<{ id: string }>
+  ? Array<Reference>
+  : SourceType;
+
+export interface ReadFieldFunction {
+  <T, K extends keyof T = keyof T>(
+    context: FieldFunctionOptions,
+    options: ReadFieldOptions
+  ): DeepReference<T[K]>;
+
+  <T, K extends keyof T = keyof T>(
+    context: FieldFunctionOptions,
+    fieldName: K,
+    from?: Reference | StoreObject | undefined
+  ): DeepReference<T[K]>;
+}

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -1,6 +1,6 @@
 import EntityTypeMap from "../entity-store/EntityTypeMap";
-import { DocumentNode, FieldNode } from 'graphql';
-import { Cache, FieldFunctionOptions, Reference, StoreObject, StoreValue } from '@apollo/client';
+import { FieldNode } from 'graphql';
+import { Cache, Reference, StoreObject, StoreValue } from '@apollo/client';
 
 export interface FieldSpecifier {
   typename?: string;
@@ -105,30 +105,3 @@ export interface InvalidationPolicyManagerConfig {
 export type InvalidationPolicyEventActivation = {
   [key in InvalidationPolicyEvent]: boolean;
 };
-export interface TypePoliciesSchemaInterface<TypedTypePolicies> {
-  typeDefs?: DocumentNode;
-  typePolicies: TypedTypePolicies;
-}
-
-export type DeepReference<SourceType> = SourceType extends Record<string, any>
-  ? SourceType extends { id: string }
-  ? Reference
-  : {
-    [K in keyof SourceType]: DeepReference<SourceType[K]>;
-  }
-  : SourceType extends Array<{ id: string }>
-  ? Array<Reference>
-  : SourceType;
-
-export interface ReadFieldFunction {
-  <T, K extends keyof T = keyof T>(
-    context: FieldFunctionOptions,
-    options: ReadFieldOptions
-  ): DeepReference<T[K]>;
-
-  <T, K extends keyof T = keyof T>(
-    context: FieldFunctionOptions,
-    fieldName: K,
-    from?: Reference | StoreObject | undefined
-  ): DeepReference<T[K]>;
-}

--- a/tests/EntityStoreWatcher.test.ts
+++ b/tests/EntityStoreWatcher.test.ts
@@ -23,7 +23,7 @@ describe("#EntityStoreWatcher", () => {
       policies,
       entityTypeMap,
       entityStore,
-      updateCanonicalField: () => { }
+      updateCollectionField: () => { }
     });
   });
 
@@ -48,7 +48,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
-        updateCanonicalField: () => { }
+        updateCollectionField: () => { }
       });
       const mergeArgs: [string, StoreObject] = [
         "ROOT_QUERY",
@@ -107,7 +107,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
-        updateCanonicalField: () => { }
+        updateCollectionField: () => { }
       });
       entityStore.delete("ROOT_QUERY", "employees", undefined);
       expect(deleteSpy).toHaveBeenCalledWith(
@@ -155,7 +155,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
-        updateCanonicalField: () => { }
+        updateCollectionField: () => { }
       });
       entityStore.clear();
       expect(clearSpy).toHaveBeenCalled();
@@ -179,7 +179,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
-        updateCanonicalField: () => { }
+        updateCollectionField: () => { }
       });
     });
 
@@ -232,7 +232,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
-        updateCanonicalField: () => { }
+        updateCollectionField: () => { }
       });
       const entityStoreWatcherMergeSpy = jest
         // @ts-ignore

--- a/tests/EntityStoreWatcher.test.ts
+++ b/tests/EntityStoreWatcher.test.ts
@@ -23,6 +23,7 @@ describe("#EntityStoreWatcher", () => {
       policies,
       entityTypeMap,
       entityStore,
+      updateCanonicalField: () => { }
     });
   });
 
@@ -47,6 +48,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
+        updateCanonicalField: () => { }
       });
       const mergeArgs: [string, StoreObject] = [
         "ROOT_QUERY",
@@ -105,6 +107,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
+        updateCanonicalField: () => { }
       });
       entityStore.delete("ROOT_QUERY", "employees", undefined);
       expect(deleteSpy).toHaveBeenCalledWith(
@@ -152,6 +155,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
+        updateCanonicalField: () => { }
       });
       entityStore.clear();
       expect(clearSpy).toHaveBeenCalled();
@@ -175,6 +179,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
+        updateCanonicalField: () => { }
       });
     });
 
@@ -227,6 +232,7 @@ describe("#EntityStoreWatcher", () => {
         policies,
         entityTypeMap,
         entityStore,
+        updateCanonicalField: () => { }
       });
       const entityStoreWatcherMergeSpy = jest
         // @ts-ignore

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -259,6 +259,25 @@ describe("Cache", () => {
           expect(matchingEntities).toEqual([employee]);
         });
       });
+
+      describe('with no filter', () => {
+        test('should return all entities of the given type', () => {
+          const employeeFragment = gql`
+            fragment employee on Employee {
+              id
+              employee_name
+              employee_age
+              employee_salary
+            }
+          `;
+
+          const matchingEntities = cache.readFragmentWhere<EmployeeType>({
+            fragment: employeeFragment,
+          });
+
+          expect(matchingEntities).toEqual([employee, employee2]);
+        });
+      });
     });
   });
 

--- a/tests/fixtures/employee.ts
+++ b/tests/fixtures/employee.ts
@@ -2,7 +2,14 @@ import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import { createFixture } from "./utils";
 
-export default createFixture("Employee", (index: number) => ({
+export interface EmployeeType {
+  id: string,
+  employee_name: string;
+  employee_salary: number;
+  employee_age: number;
+}
+
+export default createFixture<EmployeeType>("Employee", (index: number) => ({
   id: uuid(),
   employee_name: `Test Employee ${index}`,
   employee_salary: _.random(50000, 150000),

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -4,9 +4,9 @@ interface toRefContext {
   [key: string]: any;
 }
 
-type FixtureGenerator = (data?: object) => Fixture;
+type FixtureGenerator<T = any> = (data?: object) => Fixture<T>;
 
-export interface Fixture {
+export type Fixture<T> = T & {
   [key: string]: any;
   __typename: string;
   toRef: () => string;
@@ -18,16 +18,16 @@ function toRef(this: toRefContext) {
 
 const fixtures: { [key: string]: () => FixtureGenerator } = {};
 
-export const createFixture = (
+export const createFixture = <T>(
   typename: string,
   generator: (index: number) => object
-) => {
+): FixtureGenerator<T> => {
   fixtures[typename] = (): FixtureGenerator => {
     let count = 0;
 
     return (data?: object) => {
       count += 1;
-      const fixtureObject = _.assign(generator(count), data) as Fixture;
+      const fixtureObject = _.assign(generator(count), data) as Fixture<T>;
       fixtureObject.__typename = typename;
       fixtureObject.toRef = toRef;
       Object.defineProperty(fixtureObject, "toRef", {
@@ -41,5 +41,7 @@ export const createFixture = (
     };
   };
 
-  return fixtures[typename]();
+  const fixture = fixtures[typename] as () => FixtureGenerator<T>;
+
+  return fixture();
 };


### PR DESCRIPTION
Experimental support for accessing and filtering entity collections by typename from the Apollo cache using the new `useFragment` and `useFragmentWhere` hooks.

This change introduces the concept of data entity collections, grouped by type. It is currently difficult to perform queries for entities of a particular type from the Apollo cache, such as all `Employee` entities in the cache with `age == 42`. Since the cache does not group entities by type, you would need to create a pseudo collection field by writing a field to the root query and always keeping it up to date when new entities of that type are added/removed.

If you then wanted to perform the filter by age, you would need to write another type policy called `employeesAboveAge` that filters the pseudo collection down further.

This ends up being a lot of overhead and developer maintenance to do manually and could be made easier. This feature supports automatic collection grouping of entities in the cache, which can then be queried using the new `useFragment` and `useFragmentWhere` as well as the `watchFragment` and `watchFragmentWhere` APIs.

an example of using the hooks might look like this:

```
  const { data } = useFragment(
    gql`
      fragment GetEmployee on Employee {
        id
      }
    `,
    {
      id: 'Employee:1',
    }
  );
```

```
  const { data } = useFragmentWhere(
    gql`
      fragment GetEmployeesByAge on Employee {
        id
        first_name
      }
   `,
    {
      employee_age: 42,
    }
  );
```

This is still an experimental implementation requiring some further cleanup/testing but the PR is up early for feedback from folks.

### Proposed implementation

Whenever a normalized entity like an `Employee:1` object is written to the cache, a reference is also added to a `CacheExtensionsCollectionEntity` entity for that type, with ID `CacheExtensionsCollectionEntity:TypeName` that is shaped like this:

```
{
  "ROOT_QUERY": {...},
  "CacheExtensionsCollectionEntity:Employee": {
    data: [{ __ref: 'Employee:1']}
    __typename: "CacheExtensionsCollectionEntity",
    id: "Employee"
  },
  "Employee:1": {...},
}
``` 

With the list of entities by type now maintained in the cache, we can then add support watching for updates to the full or filtered collection. While there is a matching `readFragment` API available as a counterpart to `readQuery`, there is no built-in `useFragment` or `watchFragment` API for `useQuery` or `watchQuery`. This is likely because entities themselves are not watchable in the Apollo cache, only queries support the observable API necessary for subscribing to changes.

To overcome this limitation and introduce the `useFragment`, `watchFragment` and new `useFragmentWhere` APIs, we automatically generate a type policy for these calls and access the data from the collection entities. This way, whenever any fields requested in the fragment change in the cache, the type policy will update and deliver new data, just like a manually defined type policy would.

### Open API questions

Right now it creates the automatically generated type policies by fragment name. Fragment and query names should be unique across apps since conflicting ones would break tools like TS type generation. The alternative to relying on fragment names here would be to have the new APIs like `useFragmentWhere` support a `name` or `alias` field to cache it under, which can be done but adds a bit more developer overhead.

I will probably list a few more things here as people point them out/I think through why this is all a bad idea 🙃 