### PR TITLE
expose args as well as variables in the policy action entity meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.2 (Dan Reynolds)
+
+- Expose args field on policy action meta objects
+
 1.2.1 (Dan Reynolds)
 
 - Publish publicly. Sorry OSS friends!

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ const cache = new InvalidationPolicyCache({
 | `fieldName`          | The field for the entity in the Apollo cache            | string?             | `employees`                                                                                 |
 | `storeFieldName`     | The `fieldName` combined with its distinct variables    | string?             | `employees({ location: 'US' })`                                                             |
 | `variables`          | The variables the entity was written with               | Object?             | `{ location: 'US' }`                                                                        |
-| `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                        |
+| `args`               | The args the field was written with                     | Object?             | `{ location: 'US' }`                                                                        |
+| `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                    |
 | `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
 
 | Default Policy Action Entity | Description                                                                   | Type               | Example                                                                                     |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -2,6 +2,7 @@ import _ from "lodash";
 import { FieldNode, SelectionNode } from "graphql";
 import { Cache, makeReference } from "@apollo/client/core";
 import {
+  argumentsObjectFromField,
   createFragmentMap,
   getFragmentDefinitions,
   getFragmentFromSelection,
@@ -260,11 +261,11 @@ export class CacheResultProcessor {
             variables,
           });
 
-          const hasFieldArgs = (field?.arguments?.length ?? 0) > 0;
-          const fieldVariables = variables ?? (hasFieldArgs ? {} : undefined);
+          const fieldArgs = argumentsObjectFromField(field, variables);
+          const fieldVariables = variables ?? (fieldArgs !== null ? {} : undefined);
 
           // Write a query to the entity type map at `write` in addition to `merge` time so that we can keep track of its variables.
-          entityTypeMap.write(typename, dataId, storeFieldName, fieldVariables);
+          entityTypeMap.write(typename, dataId, storeFieldName, fieldVariables, fieldArgs);
 
           const renewalPolicy = invalidationPolicyManager.getRenewalPolicyForType(
             typename
@@ -283,6 +284,7 @@ export class CacheResultProcessor {
               storeFieldName,
               ref: makeReference(dataId),
               variables: fieldVariables,
+              args: fieldArgs,
             },
           });
         }

--- a/src/entity-store/EntityTypeMap.ts
+++ b/src/entity-store/EntityTypeMap.ts
@@ -105,7 +105,8 @@ export default class EntityTypeMap {
     typename: string,
     dataId: string,
     storeFieldName?: string | null,
-    variables?: Record<string, any>
+    variables?: Record<string, any>,
+    args?: Record<string, any> | null
   ) {
     const fieldName = storeFieldName
       ? fieldNameFromStoreName(storeFieldName)
@@ -119,9 +120,11 @@ export default class EntityTypeMap {
           .entries[storeFieldName];
         if (storeFieldNameEntry) {
           storeFieldNameEntry.variables = variables;
+          storeFieldNameEntry.args = args;
         } else {
           existingTypeMapEntity.storeFieldNames!.entries[storeFieldName] = {
             variables,
+            args,
           };
           existingTypeMapEntity.storeFieldNames!.__size++;
         }
@@ -138,7 +141,7 @@ export default class EntityTypeMap {
           storeFieldNames: {
             __size: 1,
             entries: {
-              [storeFieldName]: { variables, cacheTime },
+              [storeFieldName]: { variables, args, cacheTime },
             },
           },
         };

--- a/src/entity-store/types.ts
+++ b/src/entity-store/types.ts
@@ -16,6 +16,7 @@ export interface TypeMapEntity {
       [index: string]: {
         cacheTime?: number;
         variables?: Record<string, any>;
+        args?: Record<string, any> | null;
       };
     };
   };

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -124,6 +124,7 @@ export default class InvalidationPolicyManager {
               fieldName,
               storeFieldName,
               variables: storeFieldNames.entries[storeFieldName].variables,
+              args: storeFieldNames.entries[storeFieldName].args,
               ref: makeReference(dataId),
               storage: this.getPolicyActionStorage(storeFieldName),
               ...policyMeta,

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -48,6 +48,7 @@ export interface PolicyActionFields {
   storeFieldName?: string;
   storage: PolicyActionStorage,
   variables?: Record<string, any>;
+  args?: Record<string, any> | null;
 }
 
 export type PolicyActionEntity = PolicyActionFields & PolicyActionMeta;

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -752,6 +752,7 @@ describe("Cache", () => {
                     __size: 1,
                     entries: {
                       employees: {
+                        args: null,
                         cacheTime: 0,
                         variables: {},
                       },
@@ -832,6 +833,7 @@ describe("Cache", () => {
                       'employees({"name":"Tester McTest"})': {
                         cacheTime: 0,
                         variables: { name: "Tester McTest" },
+                        args: { name: "Tester McTest" }
                       },
                     },
                   },
@@ -877,6 +879,9 @@ describe("Cache", () => {
                         variables: {
                           name: "Tester McTest",
                           unsupportedField: true,
+                        },
+                        args: {
+                          name: "Tester McTest",
                         },
                       },
                     },


### PR DESCRIPTION
Queries with variables like:

```
gql`
  query GetEmployees($name: String!) {
    employeesFilter(
      filterInput: { name: $name }
    ) {
     id
     name
    }
  }
```

are exposed on the policy action entity, but what is not exposed is the argument to the field, in this case:

```
{ filterInput: { name: $name } }
```

Without exposing these args, it's impossible to read the field from the cache in the policy action such as:

```
EmployeesResponse: {
  onWrite: {
    OtherType: (actions, { parent }) => {
      const parentResp = readField({
        fieldName: parent.fieldName,
        from: parent.ref,
        args: ??
     })
    }
  }
}
```
 In this case, we cannot recreate the args since we only had the variables `{ name: $name }` not the full input args:
`{ filterInput: { name: $name } }`.

To fix this, let's expose the field's args in addition to the operation's variables.