### PR TITLE
reset entity store watcher and type map with init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.4.0 (Dan Reynolds)
+
+- Support Apollo 3.4 `init` API to reset the entity type map and watcher.
+
 1.3.0 (Dan Reynolds)
 
 - Adds experimental normalized collections

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.15.tgz",
-      "integrity": "sha512-CnlT9i7TgHagkKQNvti81A9KcbIMqgpUPGJJL6bg5spTsB2R/5J6E7qiPcMvXuuXwR2xe4FmE4Ey4HizStb8Hg==",
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.16.tgz",
+      "integrity": "sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==",
       "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/NerdWalletOSS/apollo-cache-policies#readme",
   "peerDependencies": {
-    "@apollo/client": "^3.4.15",
+    "@apollo/client": "^3.4.16",
     "react": "^16.8.0"
   },
   "dependencies": {
@@ -40,7 +40,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "@apollo/client": "^3.4.15",
+    "@apollo/client": "^3.4.16",
     "@types/jest": "^25.2.3",
     "@types/react": "^17.0.19",
     "jest": "^25.5.4",


### PR DESCRIPTION
The Apollo 3.4 `init` API as seen here https://github.com/apollographql/apollo-client/commit/19210dec11a8462c88a4f98f667803dd01c328bd resets the entity store but it would cause the `EntityTypeMap` and `EntityStoreWatcher` to get out of sync. Now calling `init` also resets the store watcher and type map as expected.