### PR TITLE
fix a bug where fields with aliases and an expired TTL were not evicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.0.2 (Dan Reynolds)
+
+* Fix a bug with evicting expired fields with a field alias
+
 2.0.1 (Dan Reynolds)
 
 * Fix issue with custom Query type keyArgs preventing TTLs from evicting entities

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -147,7 +147,11 @@ export class CacheResultProcessor {
         const aggregateResultComplete = this.getFieldsForQuery(options).reduce<
           boolean
         >((acc, field) => {
-          const fieldName = resultKeyNameFromField(field);
+          const fieldName = field.name.value;
+          // While the field name is used as the key in the cache, the result object
+          // will have it keyed by an alias name if provided so we keep track of the 
+          // result key name in case it needs to be removed from the response due to an evicted TTL
+          const resultKeyName = resultKeyNameFromField(field);
           const subResultStatus = this.processReadSubResult(result, fieldName);
 
           const typename = entityTypeMap.readEntityById(
@@ -194,7 +198,7 @@ export class CacheResultProcessor {
             });
 
             if (evictedByStoreFieldNameForEntity || evictedByStoreFieldNameForQuery) {
-              delete (result as Record<string, any>)[fieldName];
+              delete (result as Record<string, any>)[resultKeyName];
               return false;
             }
           }
@@ -264,7 +268,7 @@ export class CacheResultProcessor {
 
     if (dataId && isQuery(dataId) && _.isPlainObject(result)) {
       this.getFieldsForQuery(options).forEach((field) => {
-        const fieldName = resultKeyNameFromField(field);
+        const fieldName = field.name.value;
         const typename = entityTypeMap.readEntityById(
           makeEntityId(dataId, fieldName)
         )?.typename;


### PR DESCRIPTION
Closes a second issue described in #39. Fields with aliases are stored by their field name, not their alias name in the cache so we were trying to look them up in the `EntityTypeMap` by their alias name and incorrectly missing evicting them. This fix handles properly evicting expired aliased fields and filtering them out of the returned query result.