### PR TITLE
add support for reactive filter changes in useFragmentWhere

### DIFF
--- a/src/client/ApolloExtensionsClient.ts
+++ b/src/client/ApolloExtensionsClient.ts
@@ -2,6 +2,7 @@ import {
   ApolloClient,
   ApolloClientOptions,
   DocumentNode,
+  makeVar,
   ObservableQuery,
 } from '@apollo/client/core';
 import { Policies } from '@apollo/client/cache/inmemory/policies';
@@ -72,7 +73,7 @@ export default class ApolloExtensionsClient<TCacheShape> extends ApolloClient<TC
   // Watches the data in the cache similarly to watchQuery for a given fragment.
   watchFragment(
     options: WatchFragmentOptions,
-  ): ObservableQuery {
+  ) {
     const fieldName = generateFragmentFieldName();
     const query = buildWatchFragmentQuery({
       ...options,
@@ -87,9 +88,12 @@ export default class ApolloExtensionsClient<TCacheShape> extends ApolloClient<TC
   // matching the given filter.
   watchFragmentWhere<FragmentType>(options: WatchFragmentWhereOptions<FragmentType>) {
     const fieldName = generateFragmentFieldName();
+    const filterVar = makeVar(options.filter);
+
     const query = buildWatchFragmentWhereQuery({
       ...options,
       fieldName,
+      filterVar,
       cache: this.cache as unknown as InvalidationPolicyCache,
       policies: this.policies,
     });

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -2,7 +2,8 @@ import { DocumentNode, FragmentDefinitionNode } from 'graphql';
 import { WatchFragmentOptions, WatchFragmentWhereOptions } from './types';
 import { InvalidationPolicyCache } from '../cache';
 import { Policies } from '@apollo/client/cache/inmemory/policies';
-import { makeReference } from '@apollo/client/core';
+import { makeReference, ReactiveVar } from '@apollo/client/core';
+import { FragmentWhereFilter } from '../cache/types';
 
 function _generateQueryFromFragment({
   fieldName,
@@ -83,9 +84,10 @@ export function buildWatchFragmentQuery(
 export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmentWhereOptions<FragmentType> & {
   cache: InvalidationPolicyCache;
   policies: Policies;
+  filterVar: ReactiveVar<FragmentWhereFilter<FragmentType> | undefined>;
   fieldName: string;
 }): DocumentNode {
-  const { fragment, filter, policies, cache, fieldName, } = options;
+  const { fragment, filterVar, policies, cache, fieldName, } = options;
   const fragmentDefinition = fragment.definitions[0] as FragmentDefinitionNode;
   const __typename = fragmentDefinition.typeCondition.name.value;
 
@@ -105,7 +107,7 @@ export function buildWatchFragmentWhereQuery<FragmentType>(options: WatchFragmen
             read(_existing) {
               return cache.readReferenceWhere({
                 __typename,
-                filter,
+                filter: filterVar(),
               });
             }
           }

--- a/src/hooks/useFragmentWhere.ts
+++ b/src/hooks/useFragmentWhere.ts
@@ -1,5 +1,5 @@
 import { getApolloContext } from '@apollo/client';
-import { useContext } from 'react';
+import { useContext, useRef } from 'react';
 import { DocumentNode } from 'graphql';
 import InvalidationPolicyCache from '../cache/InvalidationPolicyCache';
 import { buildWatchFragmentWhereQuery } from '../client/utils';
@@ -7,6 +7,8 @@ import { FragmentWhereFilter } from '../cache/types';
 import { useOnce } from './utils';
 import { useFragmentTypePolicyFieldName } from './useFragmentTypePolicyFieldName';
 import { useGetQueryDataByFieldName } from './useGetQueryDataByFieldName';
+import { makeVar } from '@apollo/client';
+import { useDeepMemo } from '@apollo/client/react/hooks/utils/useDeepMemo';
 
 // A hook for subscribing to a fragment for entities in the Apollo cache matching a given filter from a React component.
 export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, filter?: FragmentWhereFilter<FragmentType>) {
@@ -14,9 +16,14 @@ export default function useFragmentWhere<FragmentType>(fragment: DocumentNode, f
   const client = context.client;
   const cache = client?.cache as unknown as InvalidationPolicyCache;
   const fieldName = useFragmentTypePolicyFieldName();
+  const filterVarRef = useRef(makeVar<FragmentWhereFilter<FragmentType> | undefined>(filter));
+  const filterVar = filterVarRef.current;
+
+  useDeepMemo(() => filterVar(filter), filter);
 
   const query = useOnce(() => buildWatchFragmentWhereQuery({
     filter,
+    filterVar,
     fragment,
     fieldName,
     cache,


### PR DESCRIPTION
Currently the filter passed to `useFragmentWhere` is static. If you change the values passed in the filter, it has no effect. This is non-intuitive and makes the feature less powerful. The filter arguments are now able to be updated dynamically to re-trigger computation of the query.