### PR TITLE
fix bug with duplicate collection references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.1.1 (Dan Reynolds)
+
+Fix duplicate collection references bug.
+
 3.1.0 (Dan Reynolds)
 
 Add support for a `limit` field to `fragmentWhere` APIs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -300,15 +300,22 @@ export default class InvalidationPolicyCache extends InMemoryCache {
       fields: {
         data: (existing, { canRead }) => {
           const existingReferences = existing as Reference[];
+          let hasDuplicateRef = false;
 
           const existingReferencesById = existingReferences.reduce((acc, ref) => {
-            acc[ref.__ref] = ref;
+            const { __ref } = ref;
+
+            if (!hasDuplicateRef && acc[__ref]) {
+              hasDuplicateRef = true;
+            }
+            acc[__ref] = ref;
+
             return acc;
           }, {} as Record<string, Reference>);
 
           const newReferences = Object.values(updatedReferences).filter((ref) => !existingReferencesById[ref.__ref] && canRead(ref));
 
-          if (newReferences.length === 0) {
+          if (!hasDuplicateRef && newReferences.length === 0) {
             return existing;
           }
 


### PR DESCRIPTION
There was a bug where if you evict data, its reference in it's collection entity list is duplicated when it is later written back into the cache. This is because eviction doesn't eagerly remove the reference and the updating of the collection list wasn't filtering out entities that already exist in the list.

In this change, we update the collection list merge function to remove duplicates.