### PR TITLE
add support for specifying the fragment name in useFragmentWhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.3.0 (Dan Reynolds)
+
+Add support for specifying the fragment name to use in the `useFragmentWhere` API.
+
 3.2.0 (Dan Reynolds)
 
 Add support for an `orderBy` field to `fragmentWhere` API.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,6 +40,10 @@ export function fieldNameFromStoreName(storeFieldName: string) {
 // a leading prefix in order to distinguish it as a fragment policy and
 // prevent the UUID from being trimmed by the `fieldNameFromStoreFieldName` regex.
 // https://github.com/apollographql/apollo-client/blob/d9a1039d36801d450a79cb56870f0a351044254b/src/cache/inmemory/helpers.ts#L80
-export function generateFragmentFieldName() {
-  return `-fragment-${v4()}`;
+export function generateFragmentFieldName({
+  fragmentName,
+}: {
+  fragmentName?: string;
+} = {}) {
+  return `-fragment-${fragmentName ?? v4()}`;
 }

--- a/src/hooks/useFragmentTypePolicyFieldName.ts
+++ b/src/hooks/useFragmentTypePolicyFieldName.ts
@@ -1,18 +1,26 @@
 import { useApolloClient } from "@apollo/client";
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo } from "react"
 import { InvalidationPolicyCache } from "../cache";
 import { generateFragmentFieldName } from "../helpers";
+import { usePrevious } from "./utils";
 
 // Creates a field name to be used for a dynamically added field policy.
-export const useFragmentTypePolicyFieldName = (): string => {
-  const { current: fieldName } = useRef(generateFragmentFieldName());
+export const useFragmentTypePolicyFieldName = ({
+  fragmentName,
+}: {
+  fragmentName?: string;
+} = {}): string => {
+  const fieldName = useMemo(() => generateFragmentFieldName({ fragmentName }), [fragmentName]);
+  const prevFieldName = usePrevious(fieldName);
   const client = useApolloClient();
 
   useEffect(() =>
-    // @ts-ignore After the component using the hook is torn down, remove the dynamically added type policy
-    // for this hook from the type policies list.
-    () => delete (client.cache as InvalidationPolicyCache).policies.typePolicies.Query.fields[fieldName],
-    [],
+    () => {
+      // @ts-ignore After the component using the hook is torn down, remove the dynamically added type policy
+      // for this hook from the type policies list.
+      delete (client.cache as InvalidationPolicyCache).policies.typePolicies.Query.fields[prevFieldName];
+    },
+    [fieldName, prevFieldName],
   );
 
   return fieldName;

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import isFunction from "lodash/isFunction";
 
 export function useOnce<T>(value: T | (() => T)): T {
@@ -14,3 +14,11 @@ export function useOnce<T>(value: T | (() => T)): T {
   }
   return valueRef.current as T;
 }
+
+export const usePrevious = <T>(value: T): T | null => {
+  const ref = useRef<T | null>(null);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};


### PR DESCRIPTION
Adding support for specifying the fragment name to use in the `useFragmentWhere` API so that clients can force a re-query of data that returns new results.