### PR TITLE
fix(cache-result-processor): diff should use alias name in partial read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.3.1 (Dan Reynolds)
+
+Bugfix for aliased queries with variables: https://github.com/NerdWalletOSS/apollo-cache-policies/issues/83
+Reporter: https://github.com/SavelevMatthew
+
 3.3.0 (Dan Reynolds)
 
 Add support for specifying the fragment name to use in the `useFragmentWhere` API.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -153,7 +153,7 @@ export class CacheResultProcessor {
           // will have it keyed by an alias name if provided so we keep track of the 
           // result key name in case it needs to be removed from the response due to an evicted TTL
           const resultKeyName = resultKeyNameFromField(field);
-          const subResultStatus = this.processReadSubResult(result, resultKeyName || fieldName);
+          const subResultStatus = this.processReadSubResult(result, resultKeyName);
 
           const typename = entityTypeMap.readEntityById(
             makeEntityId(dataId, fieldName)

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -153,7 +153,7 @@ export class CacheResultProcessor {
           // will have it keyed by an alias name if provided so we keep track of the 
           // result key name in case it needs to be removed from the response due to an evicted TTL
           const resultKeyName = resultKeyNameFromField(field);
-          const subResultStatus = this.processReadSubResult(result, fieldName);
+          const subResultStatus = this.processReadSubResult(result, resultKeyName || fieldName);
 
           const typename = entityTypeMap.readEntityById(
             makeEntityId(dataId, fieldName)

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -1813,10 +1813,44 @@ describe("InvalidationPolicyCache", () => {
           },
         });
 
+        let queryResult = cache.readQuery({
+          query: employeesAndBossesWithVariablesQuery,
+          variables: {
+            employeeName: "Tester McTest",
+            bossName: "Tester McBoss"
+          },
+        });
+        expect(queryResult).toEqual({
+          employees: {
+            __typename: 'EmployeesResponse',
+            data: [employee, employee2]
+          },
+          bosses: {
+            __typename: 'EmployeesResponse',
+            data: [employee3]
+          }
+        });
+        expect(cache.extract(true, false)).toEqual({
+          [employee.toRef()]: employee,
+          [employee2.toRef()]: employee2,
+          [employee3.toRef()]: employee3,
+          ROOT_QUERY: {
+            __typename: "Query",
+            "employees({\"name\":\"Tester McTest\"})": {
+              __typename: "EmployeesResponse",
+              data: [{ __ref: employee.toRef() }, { __ref: employee2.toRef() }],
+            },
+            "employees({\"name\":\"Tester McBoss\"})": {
+              __typename: "EmployeesResponse",
+              data: [{ __ref: employee3.toRef() }],
+            },
+          },
+        });
+
         dateNowSpy.mockRestore();
         dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(101);
 
-        const queryResult = cache.readQuery({
+         queryResult = cache.readQuery({
           query: employeesAndBossesWithVariablesQuery,
           variables: {
             employeeName: "Tester McTest",
@@ -1833,7 +1867,8 @@ describe("InvalidationPolicyCache", () => {
           },
         });
       });
-      test('should return empty diff result on alias with no typename array response if ttl expired', () => {
+
+      test('should evict an expired array response entity with a field alias', () => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
             timeToLive: 100,
@@ -1848,20 +1883,49 @@ describe("InvalidationPolicyCache", () => {
           },
         });
 
+        let queryResult = cache.readQuery({
+          query: employeesWithAliasVariablesAndArrayResponseQuery,
+          variables: {
+            employeeName: "Tester McTest",
+            bossName: "Tester McBoss"
+          },
+        });
+        expect(queryResult).toEqual({
+          bosses: [
+            employee3,
+          ]
+        });
+
+        expect(cache.extract(true, false)).toEqual({
+          [employee3.toRef()]: employee3,
+          ROOT_QUERY: {
+            __typename: "Query",
+            "employees({\"name\":\"Tester McBoss\"})": [{ __ref: employee3.toRef() }],
+          },
+        });
+
         dateNowSpy.mockRestore();
         dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(101);
 
-        const diff = cache.diff({
+        queryResult = cache.readQuery({
           query: employeesWithAliasVariablesAndArrayResponseQuery,
           variables: {
+            employeeName: "Tester McTest",
             bossName: "Tester McBoss"
           },
-          optimistic: true,
-        })
-        expect(diff).toHaveProperty('complete', false)
-        expect(diff).toHaveProperty('result', {
-          bosses: []
-        })
+        });
+
+        expect(queryResult).toEqual({
+          bosses: [],
+        });
+        expect(cache.extract(true, false)).toEqual({
+          ROOT_QUERY: {
+            __typename: "Query",
+            // The employees field remains in the cache since it's cached value has no __typename field and is not evicted
+            // itself when read.
+            "employees({\"name\":\"Tester McBoss\"})": [{ __ref: employee3.toRef() }],
+          },
+        });
       });
     });
 


### PR DESCRIPTION
This PR closes issue #83, when query returning array of objects directly without `__typename`

- [x] Issue fixed
- [x] Test case added
- [x] All existing tests run fine