### PR TITLE
fix bug where non-typed responses are not evicted by query TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.3.2 (Dan Reynolds)
+
+Fixes bug where query responses without a typename are never evicted.
+
+Bugfix: https://github.com/NerdWalletOSS/apollo-cache-policies/issues/81
+Reporter: https://github.com/qwertypomy
+
 3.3.1 (Dan Reynolds)
 
 Bugfix for aliased queries with variables: https://github.com/NerdWalletOSS/apollo-cache-policies/issues/83

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "3.3.0",
+  "version": "3.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nerdwallet/apollo-cache-policies",
-      "version": "3.3.0",
+      "version": "3.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^16.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdwallet/apollo-cache-policies",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "An extension to the InMemoryCache from Apollo that adds additional cache policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/entity-store/EntityStoreWatcher.ts
+++ b/src/entity-store/EntityStoreWatcher.ts
@@ -80,18 +80,24 @@ export default class EntityStoreWatcher {
             // If there is a valid response, it will contain the type Query and then the nested response types for each requested field. We want
             // to record a map of the types for those fields to their field store names. If there is no incoming data it is because that cache entry for storeFieldName
             // is being deleted so do nothing
-            storeFieldName !== "__typename" &&
-            (incomingStoreObject[storeFieldName] as StoreObject)?.__typename
+            storeFieldName !== "__typename"
         )
         .forEach((storeFieldName) => {
           const entityStoreObject = incomingStoreObject[
             storeFieldName
           ] as StoreObject;
-          entityTypeMap.write(
-            entityStoreObject.__typename!,
-            dataId,
-            storeFieldName
-          );
+          const typename = entityStoreObject?.__typename;
+
+          if (typename) {
+            entityTypeMap.write(
+              typename,
+              dataId,
+              storeFieldName
+            );
+          } else {
+            const queryTypename = this.config.policies.rootTypenamesById[dataId];
+            entityTypeMap.write(queryTypename, dataId, storeFieldName);
+          }
         });
     } else {
       const typename = incomingStoreObject.__typename;

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -1915,15 +1915,10 @@ describe("InvalidationPolicyCache", () => {
           },
         });
 
-        expect(queryResult).toEqual({
-          bosses: [],
-        });
+        expect(queryResult).toEqual({});
         expect(cache.extract(true, false)).toEqual({
           ROOT_QUERY: {
             __typename: "Query",
-            // The employees field remains in the cache since it's cached value has no __typename field and is not evicted
-            // itself when read.
-            "employees({\"name\":\"Tester McBoss\"})": [{ __ref: employee3.toRef() }],
           },
         });
       });


### PR DESCRIPTION
Closes #81 

Query fields are entered in the entity type map with a typename of `Query` so that they can be evicted like any other typed object when read with an expired TTL.

